### PR TITLE
Add function to easily create Matcher<View> objects.

### DIFF
--- a/espresso/src/main/java/com/elpassion/android/commons/espresso/matchers/ViewMatcher.kt
+++ b/espresso/src/main/java/com/elpassion/android/commons/espresso/matchers/ViewMatcher.kt
@@ -1,0 +1,18 @@
+package com.elpassion.android.commons.espresso.matchers
+
+import android.support.test.espresso.matcher.BoundedMatcher
+import android.view.View
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+inline fun <reified T : View> createViewMatcher(
+        crossinline matchesSafelyImpl: (view: T) -> Boolean,
+        crossinline describeToImpl: (description: Description) -> Unit): Matcher<View> {
+
+    return object : BoundedMatcher<View, T>(T::class.java) {
+
+        override fun matchesSafely(item: T) = matchesSafelyImpl(item)
+
+        override fun describeTo(description: Description) = describeToImpl(description)
+    }
+}


### PR DESCRIPTION
Pattern similar to createCreator function in :parcelable project.

Example use:

```
fun withHint(hint: String) = createViewMatcher(
        { view: EditText -> view.hint.toString() == hint },
        { it.appendText("with hint: $hint") }
)

fun withHint(hintMatcher: Matcher<String>) = createViewMatcher(
        { view: EditText -> hintMatcher.matches(view.hint.toString()) },
        { it.appendText("with hint: "); hintMatcher.describeTo(it) }
)
```