### PR TITLE
Add tests to check if there is any implementation behind assertions

### DIFF
--- a/espresso/src/androidTest/AndroidManifest.xml
+++ b/espresso/src/androidTest/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <activity android:name="com.elpassion.android.commons.espresso.OnIdTest$Activity" />
         <activity android:name="com.elpassion.android.commons.espresso.OnTextTest$Activity" />
         <activity android:name="com.elpassion.android.commons.espresso.VisibilityAssertionsTest$Activity" />
+        <activity android:name="com.elpassion.android.commons.espresso.ParentGoneChildVisiblityAssertionTest$Activity" />
         <activity android:name="com.elpassion.android.commons.espresso.HasTextAssertionsTest$Activity" />
         <activity android:name="com.elpassion.android.commons.espresso.EnableAssertionsTest$Activity" />
         <activity android:name="com.elpassion.android.commons.espresso.CheckedAssertionsTest$Activity" />

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/ParentGoneChildVisiblityAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/ParentGoneChildVisiblityAssertionTest.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout
 import com.elpassion.android.commons.espresso.test.R
+import junit.framework.AssertionFailedError
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,14 +20,28 @@ class ParentGoneChildVisiblityAssertionTest {
         onId(R.id.first).isGone()
     }
 
+    @Test(expected = AssertionFailedError::class)
+    fun shouldNotBeGoneWhenParentInvisible() {
+        onId(R.id.second).isGone()
+    }
+
     class Activity : android.app.Activity() {
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
             setContentView(FrameLayout(this).apply {
-                visibility = View.GONE
-                addView(Button(this.context).apply {
-                    id = R.id.first
-                    visibility = View.VISIBLE
+                addView(FrameLayout(context).apply {
+                    visibility = View.GONE
+                    addView(Button(context).apply {
+                        id = R.id.first
+                        visibility = View.VISIBLE
+                    })
+                })
+                addView(FrameLayout(context).apply {
+                    visibility = View.INVISIBLE
+                    addView(Button(context).apply {
+                        id = R.id.second
+                        visibility = View.VISIBLE
+                    })
                 })
             })
         }

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/ParentGoneChildVisiblityAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/ParentGoneChildVisiblityAssertionTest.kt
@@ -1,0 +1,34 @@
+package com.elpassion.android.commons.espresso
+
+import android.os.Bundle
+import android.support.test.rule.ActivityTestRule
+import android.view.View
+import android.widget.Button
+import android.widget.FrameLayout
+import com.elpassion.android.commons.espresso.test.R
+import org.junit.Rule
+import org.junit.Test
+
+class ParentGoneChildVisiblityAssertionTest {
+
+    @JvmField @Rule
+    val activityRule = ActivityTestRule(Activity::class.java)
+
+    @Test
+    fun shouldBeGoneWhenParentGone() {
+        onId(R.id.first).isGone()
+    }
+
+    class Activity : android.app.Activity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setContentView(FrameLayout(this).apply {
+                visibility = View.GONE
+                addView(Button(this.context).apply {
+                    id = R.id.first
+                    visibility = View.VISIBLE
+                })
+            })
+        }
+    }
+}

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
@@ -5,6 +5,7 @@ import android.support.design.widget.TextInputEditText
 import android.support.design.widget.TextInputLayout
 import android.support.test.rule.ActivityTestRule
 import android.widget.FrameLayout
+import com.elpassion.android.commons.espresso.test.R
 import junit.framework.AssertionFailedError
 import org.junit.Rule
 import org.junit.Test
@@ -21,7 +22,7 @@ class TextInputEditTextHasHintAssertionTest {
 
     @Test(expected = AssertionFailedError::class)
     fun shouldFailToMatch() {
-        onId(anId).textInputEditTextHasHint(R.string.abc_search_hint)
+        onId(anId).textInputEditTextHasHint(R.string.non_existing)
     }
 
     class Activity : android.app.Activity() {
@@ -40,6 +41,6 @@ class TextInputEditTextHasHintAssertionTest {
 
     companion object {
         private val anId = 123
-        private val textId = R.string.app_name
+        private val textId = R.string.existing
     }
 }

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.support.design.widget.TextInputEditText
 import android.support.design.widget.TextInputLayout
 import android.support.test.rule.ActivityTestRule
-import android.widget.FrameLayout
 import com.elpassion.android.commons.espresso.test.R
 import junit.framework.AssertionFailedError
 import org.junit.Rule
@@ -28,12 +27,10 @@ class TextInputEditTextHasHintAssertionTest {
     class Activity : android.app.Activity() {
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
-            setContentView(FrameLayout(this).apply {
-                addView(TextInputLayout(this.context).apply {
-                    addView(TextInputEditText(this.context).apply {
-                        id = anId
-                        hint = context.getString(textId)
-                    })
+            setContentView(TextInputLayout(this).apply {
+                addView(TextInputEditText(this.context).apply {
+                    id = anId
+                    hint = context.getString(textId)
                 })
             })
         }

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
@@ -5,6 +5,7 @@ import android.support.design.widget.TextInputEditText
 import android.support.design.widget.TextInputLayout
 import android.support.test.rule.ActivityTestRule
 import android.widget.FrameLayout
+import junit.framework.AssertionFailedError
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,6 +17,11 @@ class TextInputEditTextHasHintAssertionTest {
     @Test
     fun shouldConfirmTextInputEditTextHasHint() {
         onId(anId).textInputEditTextHasHint(textId)
+    }
+
+    @Test(expected = AssertionFailedError::class)
+    fun shouldFailToMatch() {
+        onId(anId).textInputEditTextHasHint(R.string.abc_search_hint)
     }
 
     class Activity : android.app.Activity() {

--- a/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
+++ b/espresso/src/androidTest/java/com/elpassion/android/commons/espresso/TextInputEditTextHasHintAssertionTest.kt
@@ -40,7 +40,7 @@ class TextInputEditTextHasHintAssertionTest {
     }
 
     companion object {
-        private val anId = 123
+        private val anId = R.id.first
         private val textId = R.string.existing
     }
 }

--- a/espresso/src/androidTest/res/values/ids.xml
+++ b/espresso/src/androidTest/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="first" type="id" />
+</resources>

--- a/espresso/src/androidTest/res/values/ids.xml
+++ b/espresso/src/androidTest/res/values/ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="first" type="id" />
+    <item name="second" type="id" />
 </resources>

--- a/espresso/src/androidTest/res/values/strings.xml
+++ b/espresso/src/androidTest/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="existing">Existing</string>
+    <string name="non_existing">Non-existing</string>
+</resources>


### PR DESCRIPTION
Without tests expecting `AssertionFailedError` the implementation could simply return `this`.
Also think of edge cases like checking visibility when parent is not visible.
Flatten test view hierarchy where possible.
Use resources defined for tests, not random ones from included libraries, cause they can be gone (or made private) at some point, causing compilation errors or warnings.